### PR TITLE
fix: Missing Members Icon in #105

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This will help you get started.
 - Basic knowledge of the terminal/command prompt.
 
 Install Dependencies:  
-Open a terminal/command prompt and use the following command: `npm run install` in the Fluent folder.
+Open a terminal/command prompt and use the following command: `npm install` in the Fluent folder.
 
 ## Development
 

--- a/src/addons/_icons.scss
+++ b/src/addons/_icons.scss
@@ -74,6 +74,11 @@
 	svg:has(path[d^='M17 11V7C17 4.243']) {
 		mask-image: url(mono.$lock-closed);
 	}
+	
+	// Members channel
+	svg:has(path[d^='M14 8.00598C14 10.211 12.206 12.006']) {
+		mask-image: url(mono.$people);
+	}
 
 	// Channel modifiers (locked/threads)
 	.iconContainer-21RCa3 {


### PR DESCRIPTION
This PR fixes the bug in #105 about how the members icon can be missing when there is a members channel. It also fixes a typo in ```CONTRIBUTING.md``` - it changes ```npm run install``` (which doesn't exist) to the correct ```npm install```.