### PR TITLE
Fix pronouns overlapping badges in popup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -22,7 +22,7 @@ _If applicable, add screenshots to help explain your problem_
 
 **Discord channel**: _Stable/PTB/Canary_  
 **OS**: _Windows/Linux/OSX_  
-**Mod**: _BetterDiscord/Powercord/GooseMod_  
+**Mod**: _BetterDiscord/Powercord/GooseMod/Vencord_  
 **Discord language**: _Your language_
 
 ### Additional context

--- a/src/theme/profile/_popout.scss
+++ b/src/theme/profile/_popout.scss
@@ -46,7 +46,7 @@
 			position: absolute;
 			right: unset;
 			left: 16px;
-			top: 66px;
+			top: 76px;
 			z-index: 2;
 			background: transparent;
 			padding: 0;


### PR DESCRIPTION
This change will add some padding for badges on the popup menu when you click on people (fixing #104). This copies the way it is done in the side panel (```_panel.scss```) by **always** adding padding, even if the user doesn't have pronouns. This may sometimes create a blank area where pronouns are usually, but unless a class is added for user pronouns (```popout.user.pronouns``` does not exist currently) it is currently what seems like the only solution.

What the solution does to people with pronouns enabled:
![image](https://github.com/DiscordStyles/Fluent/assets/87458591/dc2b33e3-1b85-42dc-b294-15f5fb9de518)

What the solution does to people with pronouns disabled:
![image](https://github.com/DiscordStyles/Fluent/assets/87458591/9f77ef9d-706b-4adb-825c-aacd6bef89b7)